### PR TITLE
Use the configured culture when writing cell values

### DIFF
--- a/src/MiniExcel/Csv/CsvWriter.cs
+++ b/src/MiniExcel/Csv/CsvWriter.cs
@@ -229,43 +229,20 @@ namespace MiniExcelLibs.Csv
             if (value == null)
                 return "";
 
-            Type type = null;
-            if (p == null)
+            if (value is DateTime dateTime)
             {
-                type = value.GetType();
-                type = Nullable.GetUnderlyingType(type) ?? type;
+                if (p?.ExcelFormat != null)
+                {
+                    return dateTime.ToString(p.ExcelFormat, _configuration.Culture);
+                }
+                return _configuration.Culture.Equals(CultureInfo.InvariantCulture) ? dateTime.ToString("yyyy-MM-dd HH:mm:ss", _configuration.Culture) : dateTime.ToString(_configuration.Culture);
             }
-            else
+            if (p?.ExcelFormat != null && value is IFormattable formattableValue)
             {
-                type = p.ExcludeNullableType; //sometime it doesn't need to re-get type like prop
+                return formattableValue.ToString(p.ExcelFormat, _configuration.Culture);
             }
 
-            
-            if (p?.ExcelFormat != null && p?.ExcelFormatToStringMethod != null)
-            {
-                return p.ExcelFormatToStringMethod.Invoke(value, new[] { p.ExcelFormat })?.ToString();
-            }
-            else if (p?.ExcelcultureToStringMethod != null && _configuration.Culture != CultureInfo.InvariantCulture)
-            {
-                return p.ExcelcultureToStringMethod.Invoke(value, new[] { _configuration.Culture })?.ToString();
-            }
-            else if (type == typeof(DateTime))
-            {
-                if (_configuration.Culture != CultureInfo.InvariantCulture)
-                {
-                    return ((DateTime)value).ToString(_configuration.Culture);
-                }
-                else if (p == null || p.ExcelFormat == null)
-                {
-                    return ((DateTime)value).ToString("yyyy-MM-dd HH:mm:ss");
-                }
-                else
-                {
-                    return ((DateTime)value).ToString(p.ExcelFormat);
-                }
-            }
-
-            return value.ToString();
+            return Convert.ToString(value, _configuration.Culture);
         }
 
     }

--- a/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.cs
@@ -357,14 +357,14 @@ namespace MiniExcelLibs.OpenXml
             {
                 v = "";
             }
-            else if (value is string)
+            else if (value is string str)
             {
-                v = ExcelOpenXmlUtils.EncodeXML(value.ToString());
+                v = ExcelOpenXmlUtils.EncodeXML(str);
             }
-            else if(p?.ExcelFormat != null && p?.ExcelFormatToStringMethod != null)
+            else if(p?.ExcelFormat != null && value is IFormattable formattableValue)
             {
-                var formatedStr = p.ExcelFormatToStringMethod.Invoke(value, new[] { p.ExcelFormat })?.ToString();
-                v = ExcelOpenXmlUtils.EncodeXML(formatedStr);
+                var formattedStr = formattableValue.ToString(p.ExcelFormat, _configuration.Culture);
+                v = ExcelOpenXmlUtils.EncodeXML(formattedStr);
             }
             else
             {

--- a/src/MiniExcel/Utils/CustomPropertyHelper.cs
+++ b/src/MiniExcel/Utils/CustomPropertyHelper.cs
@@ -5,7 +5,6 @@
     using System.Collections.Generic;
     using System.ComponentModel;
     using System.Dynamic;
-    using System.Globalization;
     using System.Linq;
     using System.Reflection;
 
@@ -19,9 +18,6 @@
         public bool Nullable { get; internal set; }
         public string ExcelFormat { get; internal set; }
         public double? ExcelColumnWidth { get; internal set; }
-
-        public MethodInfo ExcelFormatToStringMethod { get; internal set; }
-        public MethodInfo ExcelcultureToStringMethod { get; internal set; }
     }
 
     internal static partial class CustomPropertyHelper
@@ -155,15 +151,8 @@
                      var excelColumnName = p.GetAttribute<ExcelColumnNameAttribute>() ;
                      var excludeNullableType = gt ?? p.PropertyType;
                      var excelFormat = p.GetAttribute<ExcelFormatAttribute>()?.Format;
-                     MethodInfo formatToStringMethod = null;
-                     if(excelFormat != null && excludeNullableType != null)
-                     {
-                         formatToStringMethod = excludeNullableType.GetMethod("ToString", new[] { typeof(string) });
-                     }
-                     MethodInfo cultureToStringMethod = excludeNullableType.GetMethod("ToString", new[] { typeof(CultureInfo) });
                      return new ExcelCustomPropertyInfo
                      {
-
                          Property = p,
                          ExcludeNullableType = excludeNullableType,
                          Nullable = gt != null,
@@ -172,8 +161,6 @@
                          ExcelColumnIndex = p.GetAttribute<ExcelColumnIndexAttribute>()?.ExcelColumnIndex,
                          ExcelColumnWidth = p.GetAttribute<ExcelColumnWidthAttribute>()?.ExcelColumnWidth,
                          ExcelFormat = excelFormat,
-                         ExcelFormatToStringMethod = formatToStringMethod,
-                         ExcelcultureToStringMethod = cultureToStringMethod
                      };
                  });
         }


### PR DESCRIPTION
This makes `TestIssue312()` pass on a computer where the current culture is a French culture. Assert.Equal("12,345.68", rows[1].A) would fail because the value would be serialized as `12 345,68` instead of `12,345.68`.

Also simplify the implementation of the Excel and CSV writers by getting rid of both `ExcelFormatToStringMethod` and `ExcelcultureToStringMethod` which are replaced by testing if the value implements the `IFormattable` interface.